### PR TITLE
Restrict video/screen to admin

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -371,7 +371,7 @@ function App() {
 
       {/* Центр — Экран и Видео */}
       <div style={{ flex: 1, background: "#fff", borderRadius: 12, padding: 24, minHeight: 320, boxShadow: "0 0 12px #f0f2fa" }}>
-        {screenStream &&
+        {role === "admin" && screenStream &&
           <div style={{ marginBottom: 24 }}>
             <div style={{ fontWeight: 600, fontSize: 15, color: "#3476f4", marginBottom: 2 }}>
               Демонстрация экрана
@@ -408,7 +408,7 @@ function App() {
           </div>
         }
 
-        {videoStream &&
+        {role === "admin" && videoStream &&
           <div style={{ marginBottom: 24 }}>
             <div style={{ fontWeight: 600, fontSize: 15, color: "#28c36a", marginBottom: 2 }}>
               Камера пользователя


### PR DESCRIPTION
## Summary
- hide remote video and screen for regular users

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b00302030832393318ff8f36659e6